### PR TITLE
FIX: version bug error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.23.5
-opencv-python>=4.7.0.72
+opencv-python>=4.5
 pytest>=7.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.23.5
-opencv-python>=4.5
+opencv-python==4.5.0
 pytest>=7.4.2


### PR DESCRIPTION
We need to compress created fov image in factorymonitor/monitor_utils/cerebellum.py. Howeverm in yolosort container we use opencv 4.5 but skycompress wants 4.7 that cause circular import mismatch. so we need to try with version 4.5 with another tag. 